### PR TITLE
Fix deprecated warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Following options are available.
 
 * Settings for chef and paratrooper
 
-    * `:chef_version` - chef version. empty by default. use latest version by default.
+    * `:chef_version` - chef version. `latest` by default.
     * `:chef_environment` - environment setting. empty by default.
     * `:chef_roles_auto_discovery` - Enable "Chef roles Auto discovery". use `false` by default.
     * `:chef_verbose_logging`, - Enable verbose logging mode of `chef-solo`. use `true` by default.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Following options are available.
     * `:chef_roles_auto_discovery` - Enable "Chef roles Auto discovery". use `false` by default.
     * `:chef_verbose_logging`, - Enable verbose logging mode of `chef-solo`. use `true` by default.
     * `:chef_debug` - Enable debug mode of `chef-solo`. use `false` by default.
+    * `:chef_legacy_mode` - Enable legacy mode of `chef-solo`. use `false` by default. In Chef 12.11.18 or later is recommended `true`.
 
 * Settings for directories
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Following options are available.
     * `:chef_verbose_logging`, - Enable verbose logging mode of `chef-solo`. use `true` by default.
     * `:chef_debug` - Enable debug mode of `chef-solo`. use `false` by default.
     * `:chef_legacy_mode` - Enable legacy mode of `chef-solo`. use `false` by default. In Chef 12.11.18 or later is recommended `true`.
+    * `:chef_download_cookbooks` - `true` is download cookbooks by librarian-chef/Berkshelf. false is no download. use `true` by default.
 
 * Settings for directories
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Following options are available.
     * `:chef_solo_path` - the path of `chef-solo` command. use `chef-solo` by default (search command from $PATH).
     * `:chef_working_dir` - the path where chef-kitchen should installed. use `$HOME/chef-solo` by default.
     * `:chef_cache_dir` - the path for caches. use `/var/chef/cache` by default.
+    * `:chef_scp_max_concurrency` - the value for scp concurrency. use `100` by default.
 
 * Settings for chef and paratrooper
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Following options are available.
     * `:chef_debug` - Enable debug mode of `chef-solo`. use `false` by default.
     * `:chef_legacy_mode` - Enable legacy mode of `chef-solo`. use `false` by default. In Chef 12.11.18 or later is recommended `true`.
     * `:chef_download_cookbooks` - `true` is download cookbooks by librarian-chef/Berkshelf. false is no download. use `true` by default.
+    * `:chef_cookbooks_manage_tool` - `:discover` or `:librarian_chef` or `:berkshelf`. default is `:discover`.
 
 * Settings for directories
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Following options are available.
 
 * Settings for chef and paratrooper
 
+    * `:chef_version` - chef version. empty by default. use latest version by default.
     * `:chef_environment` - environment setting. empty by default.
     * `:chef_roles_auto_discovery` - Enable "Chef roles Auto discovery". use `false` by default.
     * `:chef_verbose_logging`, - Enable verbose logging mode of `chef-solo`. use `true` by default.

--- a/lib/capistrano-paratrooper-chef/chef.rb
+++ b/lib/capistrano-paratrooper-chef/chef.rb
@@ -182,17 +182,17 @@ Capistrano::Configuration.instance.load do
     end
 
     namespace :chef do
-      task :default, :except => { :no_release => true } do
+      task :default do
         before_execute
         chef.execute
       end
 
-      task :why_run, :except => { :no_release => true } do
+      task :why_run do
         before_execute
         chef.execute_why_run
       end
 
-      task :before_execute, :except => { :no_release => true } do
+      task :before_execute do
         run_list.discover
         run_list.ensure
         kitchen.ensure_cookbooks
@@ -202,7 +202,7 @@ Capistrano::Configuration.instance.load do
         chef.generate_solo_json
       end
 
-      task :solo, :except => { :no_release => true } do
+      task :solo do
         chef.default
       end
 
@@ -233,7 +233,7 @@ Capistrano::Configuration.instance.load do
       end
 
       desc "Run chef-solo"
-      task :execute, :except => { :no_release => true } do
+      task :execute do
         logger.info "Now running chef-solo"
         command = "#{chef_solo_path} -c #{remote_path("solo.rb")} -j #{remote_path("solo.json")}#{' -l debug' if fetch(:chef_debug)}"
         if run_list.unique?
@@ -247,7 +247,7 @@ Capistrano::Configuration.instance.load do
       end
 
       desc "why-run chef-solo"
-      task :execute_why_run, :except => { :no_release => true } do
+      task :execute_why_run do
         logger.info "Now running why-run chef-solo"
         command = "#{chef_solo_path} -c #{remote_path("solo.rb")} -j #{remote_path("solo.json")} -l fatal --why-run"
         if run_list.unique?
@@ -314,7 +314,7 @@ Capistrano::Configuration.instance.load do
       end
 
       desc "Upload files in kitchen"
-      task :upload, :except => { :no_release => true } do
+      task :upload do
         berkshelf.fetch
         librarian_chef.fetch
 

--- a/lib/capistrano-paratrooper-chef/chef.rb
+++ b/lib/capistrano-paratrooper-chef/chef.rb
@@ -34,6 +34,7 @@ Capistrano::Configuration.instance.load do
     set :chef_databags_path, "data_bags"
     set :chef_databag_secret, "data_bag_key"
     set :chef_scp_max_concurrency, 100
+    set :chef_download_cookbooks, true
 
     # remote chef settings
     set :chef_solo_path, "chef-solo"
@@ -318,8 +319,11 @@ Capistrano::Configuration.instance.load do
 
       desc "Upload files in kitchen"
       task :upload, :max_hosts => fetch(:chef_scp_max_concurrency) do
-        berkshelf.fetch
-        librarian_chef.fetch
+
+        if fetch(:chef_download_cookbooks)
+          berkshelf.fetch
+          librarian_chef.fetch
+        end
 
         stream = StringIO.new
         TarWriter.new(stream) do |writer|

--- a/lib/capistrano-paratrooper-chef/chef.rb
+++ b/lib/capistrano-paratrooper-chef/chef.rb
@@ -45,6 +45,7 @@ Capistrano::Configuration.instance.load do
     }
 
     # chef settings
+    set :chef_legacy_mode, false
     set :chef_roles_auto_discovery, false
     set :chef_verbose_logging, true
     set :chef_debug, false
@@ -235,7 +236,7 @@ Capistrano::Configuration.instance.load do
       desc "Run chef-solo"
       task :execute do
         logger.info "Now running chef-solo"
-        command = "#{chef_solo_path} -c #{remote_path("solo.rb")} -j #{remote_path("solo.json")}#{' -l debug' if fetch(:chef_debug)}"
+        command = "#{chef_solo_path} -c #{remote_path("solo.rb")} -j #{remote_path("solo.json")}#{' --legacy-mode' if fetch(:chef_legacy_mode)}#{' -l debug' if fetch(:chef_debug)}"
         if run_list.unique?
           sudo command
         else
@@ -249,7 +250,7 @@ Capistrano::Configuration.instance.load do
       desc "why-run chef-solo"
       task :execute_why_run do
         logger.info "Now running why-run chef-solo"
-        command = "#{chef_solo_path} -c #{remote_path("solo.rb")} -j #{remote_path("solo.json")} -l fatal --why-run"
+        command = "#{chef_solo_path} -c #{remote_path("solo.rb")} -j #{remote_path("solo.json")}#{' --legacy-mode' if fetch(:chef_legacy_mode)} -l fatal --why-run"
         if run_list.unique?
           sudo command
         else

--- a/lib/capistrano-paratrooper-chef/chef.rb
+++ b/lib/capistrano-paratrooper-chef/chef.rb
@@ -220,7 +220,7 @@ Capistrano::Configuration.instance.load do
           environment_path File.join(root, #{kitchen.environment_path.inspect})
           data_bag_path File.join(root, #{kitchen.databags_path.inspect})
           verbose_logging #{fetch(:chef_verbose_logging)}
-          Ohai::Config[:plugin_path] << '/opt/chef/plugins'
+          ohai.plugin_path << '/opt/chef/plugins'
         CONF
         if File.exist?(kitchen.databag_secret_path)
           config += <<-CONF

--- a/lib/capistrano-paratrooper-chef/chef.rb
+++ b/lib/capistrano-paratrooper-chef/chef.rb
@@ -216,6 +216,7 @@ Capistrano::Configuration.instance.load do
           environment_path File.join(root, #{kitchen.environment_path.inspect})
           data_bag_path File.join(root, #{kitchen.databags_path.inspect})
           verbose_logging #{fetch(:chef_verbose_logging)}
+          Ohai::Config[:plugin_path] << '/opt/chef/plugins'
         CONF
         if File.exist?(kitchen.databag_secret_path)
           config += <<-CONF

--- a/lib/capistrano-paratrooper-chef/chef.rb
+++ b/lib/capistrano-paratrooper-chef/chef.rb
@@ -33,6 +33,7 @@ Capistrano::Configuration.instance.load do
     set :chef_environment_path, "environments"
     set :chef_databags_path, "data_bags"
     set :chef_databag_secret, "data_bag_key"
+    set :chef_scp_max_concurrency, 100
 
     # remote chef settings
     set :chef_solo_path, "chef-solo"
@@ -316,7 +317,7 @@ Capistrano::Configuration.instance.load do
       end
 
       desc "Upload files in kitchen"
-      task :upload do
+      task :upload, :max_hosts => fetch(:chef_scp_max_concurrency) do
         berkshelf.fetch
         librarian_chef.fetch
 

--- a/lib/capistrano-paratrooper-chef/omnibus_install.rb
+++ b/lib/capistrano-paratrooper-chef/omnibus_install.rb
@@ -19,14 +19,14 @@ Capistrano::Configuration.instance.load do
   namespace :paratrooper do
     namespace :chef do
       set :chef_solo_path, "/opt/chef/bin/chef-solo"
-
+      set :chef_version, "latest"
+      
       desc "Installs chef (by omnibus installer)"
       task :install_omnibus_chef do
-        chef_version_option = exists?(:chef_version) ? " -s -- -v #{fetch(:chef_version)}" : ""
         if capture("command -v curl || true").strip.empty?
-          run "wget -O - http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash#{chef_version_option}"
+          run "wget -O - http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash -s -- -v #{fetch(:chef_version)}"
         else
-          run "curl -L http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash#{chef_version_option}"
+          run "curl -L http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash -s -- -v #{fetch(:chef_version)}"
         end
       end
       after "deploy:setup", "paratrooper:chef:install_omnibus_chef"

--- a/lib/capistrano-paratrooper-chef/omnibus_install.rb
+++ b/lib/capistrano-paratrooper-chef/omnibus_install.rb
@@ -22,10 +22,11 @@ Capistrano::Configuration.instance.load do
 
       desc "Installs chef (by omnibus installer)"
       task :install_omnibus_chef do
+        chef_version_option = fetch(:chef_version) ? " -s -- -v #{fetch(:chef_version)}" : ""
         if capture("command -v curl || true").strip.empty?
-          run "wget -O - http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash"
+          run "wget -O - http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash#{chef_version_option}"
         else
-          run "curl -L http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash"
+          run "curl -L http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash#{chef_version_option}"
         end
       end
       after "deploy:setup", "paratrooper:chef:install_omnibus_chef"

--- a/lib/capistrano-paratrooper-chef/omnibus_install.rb
+++ b/lib/capistrano-paratrooper-chef/omnibus_install.rb
@@ -22,7 +22,7 @@ Capistrano::Configuration.instance.load do
 
       desc "Installs chef (by omnibus installer)"
       task :install_omnibus_chef do
-        chef_version_option = fetch(:chef_version) ? " -s -- -v #{fetch(:chef_version)}" : ""
+        chef_version_option = exists?(:chef_version) ? " -s -- -v #{fetch(:chef_version)}" : ""
         if capture("command -v curl || true").strip.empty?
           run "wget -O - http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash#{chef_version_option}"
         else


### PR DESCRIPTION
```
WARN: Ohai::Config[:plugin_path] is set. Ohai::Config[:plugin_path] is deprecated and will be removed in future releases of ohai. Use ohai.plugin_path in your configuration file to configure :plugin_path for ohai.
```
というwarningが出てしまう問題に対処。